### PR TITLE
TASK: filter for controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Create a `Views.yaml` file in Configuration:
 
 ```
 -
-  requestFilter: 'isPackage("Psmb.Newsletter")'
+  requestFilter: 'isPackage("Psmb.Newsletter") && isController("Subscription")'
   options:
     templateRootPaths:
       - 'resource://Sfi.Site/Private/Newsletter/Templates/'


### PR DESCRIPTION
Without filtering for the right controller I had the problem that the inspector view for sending newsletter manually didn't work. The JSON view got the templatepath form the View.yaml override, which it could't handle